### PR TITLE
refactor: move Separate to Enum namespace

### DIFF
--- a/src/Enum/Separate.php
+++ b/src/Enum/Separate.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace KonradMichalik\PhpDocBlockHeaderFixer\Model;
+namespace KonradMichalik\PhpDocBlockHeaderFixer\Enum;
 
 enum Separate: string
 {

--- a/src/Generators/DocBlockHeader.php
+++ b/src/Generators/DocBlockHeader.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace KonradMichalik\PhpDocBlockHeaderFixer\Generators;
 
 use InvalidArgumentException;
-use KonradMichalik\PhpDocBlockHeaderFixer\Model\Separate;
+use KonradMichalik\PhpDocBlockHeaderFixer\Enum\Separate;
 
 use function is_string;
 

--- a/src/Rules/DocBlockHeaderFixer.php
+++ b/src/Rules/DocBlockHeaderFixer.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace KonradMichalik\PhpDocBlockHeaderFixer\Rules;
 
-use KonradMichalik\PhpDocBlockHeaderFixer\Model\Separate;
+use KonradMichalik\PhpDocBlockHeaderFixer\Enum\Separate;
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
@@ -276,7 +276,7 @@ final class DocBlockHeaderFixer extends AbstractFixer implements ConfigurableFix
             }
         }
 
-        $docBlock .= " */\n";
+        $docBlock .= ' */';
 
         return $docBlock;
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal namespace and import structure for improved organization.

* **Style**
  * Adjusted docblock formatting to remove the trailing newline after the closing tag for a cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->