### PR TITLE
feat: add option to include class name in DocBlock generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ return (new PhpCsFixer\Config())
             ],
             'preserve_existing' => true,
             'separate' => 'none',
+            'add_class_name' => true,
         ],
     ])
 ;
@@ -98,7 +99,8 @@ return (new PhpCsFixer\Config())
                 'package' => 'PhpDocBlockHeaderFixer',
             ],
             preserveExisting: true,
-            separate: \KonradMichalik\PhpDocBlockHeaderFixer\Model\Separate::None
+            separate: \KonradMichalik\PhpDocBlockHeaderFixer\Enum\Separate::None,
+            addClassName: true
         )->__toArray()
     ])
 ;

--- a/src/Generators/DocBlockHeader.php
+++ b/src/Generators/DocBlockHeader.php
@@ -35,6 +35,7 @@ final class DocBlockHeader implements Generator
         public readonly array $annotations,
         public readonly bool $preserveExisting,
         public readonly Separate $separate,
+        public readonly bool $addClassName,
     ) {}
 
     /**
@@ -44,10 +45,11 @@ final class DocBlockHeader implements Generator
         array $annotations,
         bool $preserveExisting = true,
         Separate $separate = Separate::Both,
+        bool $addClassName = false,
     ): self {
         self::validateAnnotations($annotations);
 
-        return new self($annotations, $preserveExisting, $separate);
+        return new self($annotations, $preserveExisting, $separate, $addClassName);
     }
 
     /**
@@ -60,6 +62,7 @@ final class DocBlockHeader implements Generator
                 'annotations' => $this->annotations,
                 'preserve_existing' => $this->preserveExisting,
                 'separate' => $this->separate->value,
+                'add_class_name' => $this->addClassName,
             ],
         ];
     }

--- a/tests/src/Generators/DocBlockHeaderTest.php
+++ b/tests/src/Generators/DocBlockHeaderTest.php
@@ -91,6 +91,7 @@ final class DocBlockHeaderTest extends TestCase
                 'annotations' => $annotations,
                 'preserve_existing' => false,
                 'separate' => 'top',
+                'add_class_name' => false,
             ],
         ];
 
@@ -109,6 +110,7 @@ final class DocBlockHeaderTest extends TestCase
                 'annotations' => $annotations,
                 'preserve_existing' => true,
                 'separate' => 'both',
+                'add_class_name' => false,
             ],
         ];
 
@@ -267,5 +269,45 @@ final class DocBlockHeaderTest extends TestCase
         $reflection = new ReflectionClass(DocBlockHeader::class);
 
         self::assertTrue($reflection->isFinal());
+    }
+
+    public function testCreateWithAddClassName(): void
+    {
+        $annotations = ['author' => 'John Doe'];
+        $docBlockHeader = DocBlockHeader::create(
+            $annotations,
+            true,
+            Separate::None,
+            true,
+        );
+
+        self::assertSame($annotations, $docBlockHeader->annotations);
+        self::assertTrue($docBlockHeader->preserveExisting);
+        self::assertSame(Separate::None, $docBlockHeader->separate);
+        self::assertTrue($docBlockHeader->addClassName);
+    }
+
+    public function testToArrayWithAddClassName(): void
+    {
+        $annotations = ['author' => 'John Doe'];
+        $docBlockHeader = DocBlockHeader::create(
+            $annotations,
+            false,
+            Separate::Top,
+            true,
+        );
+
+        $result = $docBlockHeader->__toArray();
+
+        $expected = [
+            'KonradMichalik/docblock_header_comment' => [
+                'annotations' => $annotations,
+                'preserve_existing' => false,
+                'separate' => 'top',
+                'add_class_name' => true,
+            ],
+        ];
+
+        self::assertSame($expected, $result);
     }
 }

--- a/tests/src/Rules/DocBlockHeaderFixerTest.php
+++ b/tests/src/Rules/DocBlockHeaderFixerTest.php
@@ -73,7 +73,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method = new ReflectionMethod($this->fixer, 'buildDocBlock');
         $method->setAccessible(true);
 
-        $result = $method->invoke($this->fixer, []);
+        $result = $method->invoke($this->fixer, [], 'TestClass');
 
         self::assertSame("/**\n */", $result);
     }
@@ -83,7 +83,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method = new ReflectionMethod($this->fixer, 'buildDocBlock');
         $method->setAccessible(true);
 
-        $result = $method->invoke($this->fixer, ['author' => 'John Doe <john@example.com>']);
+        $result = $method->invoke($this->fixer, ['author' => 'John Doe <john@example.com>'], '');
 
         $expected = "/**\n * @author John Doe <john@example.com>\n */";
         self::assertSame($expected, $result);
@@ -98,7 +98,7 @@ final class DocBlockHeaderFixerTest extends TestCase
             'author' => 'John Doe <john@example.com>',
             'license' => 'MIT',
             'package' => 'MyPackage',
-        ]);
+        ], '');
 
         $expected = "/**\n * @author John Doe <john@example.com>\n * @license MIT\n * @package MyPackage\n */";
         self::assertSame($expected, $result);
@@ -115,7 +115,7 @@ final class DocBlockHeaderFixerTest extends TestCase
                 'Jane Smith <jane@example.com>',
             ],
             'license' => 'MIT',
-        ]);
+        ], '');
 
         $expected = "/**\n * @author John Doe <john@example.com>\n * @author Jane Smith <jane@example.com>\n * @license MIT\n */";
         self::assertSame($expected, $result);
@@ -129,7 +129,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $result = $method->invoke($this->fixer, [
             'deprecated' => '',
             'author' => 'John Doe',
-        ]);
+        ], '');
 
         $expected = "/**\n * @deprecated\n * @author John Doe\n */";
         self::assertSame($expected, $result);
@@ -143,7 +143,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $result = $method->invoke($this->fixer, [
             'internal' => null,
             'license' => 'MIT',
-        ]);
+        ], '');
 
         $expected = "/**\n * @internal\n * @license MIT\n */";
         self::assertSame($expected, $result);
@@ -160,7 +160,7 @@ final class DocBlockHeaderFixerTest extends TestCase
             'internal' => null,
             'license' => 'MIT',
             'api' => '',
-        ]);
+        ], '');
 
         $expected = "/**\n * @deprecated\n * @author John Doe\n * @internal\n * @license MIT\n * @api\n */";
         self::assertSame($expected, $result);
@@ -178,12 +178,13 @@ final class DocBlockHeaderFixerTest extends TestCase
         $configDefinition = $this->fixer->getConfigurationDefinition();
         $options = $configDefinition->getOptions();
 
-        self::assertCount(3, $options);
+        self::assertCount(4, $options);
 
         $optionNames = array_map(fn ($option) => $option->getName(), $options);
         self::assertContains('annotations', $optionNames);
         self::assertContains('preserve_existing', $optionNames);
         self::assertContains('separate', $optionNames);
+        self::assertContains('add_class_name', $optionNames);
     }
 
     public function testParseExistingAnnotations(): void
@@ -284,7 +285,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method->setAccessible(true);
 
         $this->fixer->configure(['separate' => 'none']);
-        $method->invoke($this->fixer, $tokens, 1, $annotations);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'Foo');
 
         $expected = "<?php /**\n * @author John Doe\n */class Foo {}";
         self::assertSame($expected, $tokens->generateCode());
@@ -300,7 +301,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method->setAccessible(true);
 
         $this->fixer->configure(['preserve_existing' => true]);
-        $method->invoke($this->fixer, $tokens, 2, $annotations);
+        $method->invoke($this->fixer, $tokens, 2, $annotations, 'Foo');
 
         self::assertStringContainsString('@license MIT', $tokens->generateCode());
         self::assertStringContainsString('@author John Doe', $tokens->generateCode());
@@ -316,7 +317,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method->setAccessible(true);
 
         $this->fixer->configure(['preserve_existing' => false]);
-        $method->invoke($this->fixer, $tokens, 2, $annotations);
+        $method->invoke($this->fixer, $tokens, 2, $annotations, 'Foo');
 
         self::assertStringNotContainsString('@license MIT', $tokens->generateCode());
         self::assertStringContainsString('@author John Doe', $tokens->generateCode());
@@ -370,7 +371,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method = new ReflectionMethod($this->fixer, 'mergeWithExistingDocBlock');
         $method->setAccessible(true);
 
-        $method->invoke($this->fixer, $tokens, 1, $annotations);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'Foo');
 
         self::assertStringContainsString('@license MIT', $tokens->generateCode());
         self::assertStringContainsString('@author John Doe', $tokens->generateCode());
@@ -385,7 +386,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method = new ReflectionMethod($this->fixer, 'replaceDocBlock');
         $method->setAccessible(true);
 
-        $method->invoke($this->fixer, $tokens, 1, $annotations);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'Foo');
 
         self::assertStringNotContainsString('@license MIT', $tokens->generateCode());
         self::assertStringContainsString('@author John Doe', $tokens->generateCode());
@@ -401,7 +402,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method->setAccessible(true);
 
         $this->fixer->configure(['separate' => 'none']);
-        $method->invoke($this->fixer, $tokens, 1, $annotations);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'Foo');
 
         $expected = "<?php /**\n * @author John Doe\n */class Foo {}";
         self::assertSame($expected, $tokens->generateCode());
@@ -417,7 +418,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method->setAccessible(true);
 
         $this->fixer->configure(['separate' => 'top']);
-        $method->invoke($this->fixer, $tokens, 1, $annotations);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'Foo');
 
         $result = $tokens->generateCode();
         self::assertStringContainsString('@author John Doe', $result);
@@ -434,7 +435,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method->setAccessible(true);
 
         $this->fixer->configure(['separate' => 'bottom']);
-        $method->invoke($this->fixer, $tokens, 1, $annotations);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'Foo');
 
         $result = $tokens->generateCode();
         self::assertStringContainsString('@author John Doe', $result);
@@ -451,7 +452,7 @@ final class DocBlockHeaderFixerTest extends TestCase
         $method->setAccessible(true);
 
         $this->fixer->configure(['separate' => 'both']);
-        $method->invoke($this->fixer, $tokens, 1, $annotations);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'Foo');
 
         $result = $tokens->generateCode();
         self::assertStringContainsString('@author John Doe', $result);
@@ -508,5 +509,235 @@ final class DocBlockHeaderFixerTest extends TestCase
         $result = $method->invoke($this->fixer, $tokens, 2);
 
         self::assertSame(1, $result);
+    }
+
+    public function testBuildDocBlockWithClassName(): void
+    {
+        $method = new ReflectionMethod($this->fixer, 'buildDocBlock');
+        $method->setAccessible(true);
+
+        $this->fixer->configure(['add_class_name' => true]);
+        $result = $method->invoke($this->fixer, ['author' => 'John Doe'], 'MyClass');
+
+        $expected = "/**\n * MyClass.\n *\n * @author John Doe\n */";
+        self::assertSame($expected, $result);
+    }
+
+    public function testBuildDocBlockWithClassNameOnly(): void
+    {
+        $method = new ReflectionMethod($this->fixer, 'buildDocBlock');
+        $method->setAccessible(true);
+
+        $this->fixer->configure(['add_class_name' => true]);
+        $result = $method->invoke($this->fixer, [], 'MyClass');
+
+        $expected = "/**\n * MyClass.\n */";
+        self::assertSame($expected, $result);
+    }
+
+    public function testBuildDocBlockWithClassNameDisabled(): void
+    {
+        $method = new ReflectionMethod($this->fixer, 'buildDocBlock');
+        $method->setAccessible(true);
+
+        $this->fixer->configure(['add_class_name' => false]);
+        $result = $method->invoke($this->fixer, ['author' => 'John Doe'], 'MyClass');
+
+        $expected = "/**\n * @author John Doe\n */";
+        self::assertSame($expected, $result);
+    }
+
+    public function testBuildDocBlockWithEmptyClassName(): void
+    {
+        $method = new ReflectionMethod($this->fixer, 'buildDocBlock');
+        $method->setAccessible(true);
+
+        $this->fixer->configure(['add_class_name' => true]);
+        $result = $method->invoke($this->fixer, ['author' => 'John Doe'], '');
+
+        $expected = "/**\n * @author John Doe\n */";
+        self::assertSame($expected, $result);
+    }
+
+    public function testGetClassName(): void
+    {
+        $code = '<?php class MyTestClass {}';
+        $tokens = Tokens::fromCode($code);
+
+        $method = new ReflectionMethod($this->fixer, 'getClassName');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($this->fixer, $tokens, 1);
+
+        self::assertSame('MyTestClass', $result);
+    }
+
+    public function testGetClassNameWithModifiers(): void
+    {
+        $code = '<?php final class FinalClass {}';
+        $tokens = Tokens::fromCode($code);
+
+        $method = new ReflectionMethod($this->fixer, 'getClassName');
+        $method->setAccessible(true);
+
+        // Find the class token index
+        $classIndex = null;
+        for ($i = 0; $i < $tokens->count(); ++$i) {
+            if ($tokens[$i]->isGivenKind(T_CLASS)) {
+                $classIndex = $i;
+                break;
+            }
+        }
+
+        $result = $method->invoke($this->fixer, $tokens, $classIndex);
+
+        self::assertSame('FinalClass', $result);
+    }
+
+    public function testGetClassNameHitsBreakOnNonStringToken(): void
+    {
+        // Use a valid class with annotations to find a non-T_STRING token after class
+        $code = '<?php class MyClass { const TEST = 1; }';
+        $tokens = Tokens::fromCode($code);
+
+        $method = new ReflectionMethod($this->fixer, 'getClassName');
+        $method->setAccessible(true);
+
+        // Find the opening brace token (it comes after class name)
+        $braceIndex = null;
+        for ($i = 0; $i < $tokens->count(); ++$i) {
+            if ('{' === $tokens[$i]->getContent()) {
+                $braceIndex = $i - 1; // Use position just before brace
+                break;
+            }
+        }
+
+        // Call from a position where the next non-whitespace token is '{', not T_STRING
+        // This should trigger the break on line 150
+        $result = $method->invoke($this->fixer, $tokens, $braceIndex);
+
+        // The method should find no T_STRING after this position and break, returning empty
+        self::assertSame('', $result);
+    }
+
+    public function testGetClassNameReturnsEmptyWhenLoopCompletes(): void
+    {
+        $code = '<?php class MyClass {}';
+        $tokens = Tokens::fromCode($code);
+
+        $method = new ReflectionMethod($this->fixer, 'getClassName');
+        $method->setAccessible(true);
+
+        // Find the closing brace token - when we call getClassName from there,
+        // the loop should complete without finding anything and return empty string (line 153)
+        $braceIndex = null;
+        for ($i = 0; $i < $tokens->count(); ++$i) {
+            if ('}' === $tokens[$i]->getContent()) {
+                $braceIndex = $i;
+                break;
+            }
+        }
+
+        $result = $method->invoke($this->fixer, $tokens, $braceIndex);
+
+        // Should return empty string because we're at the end and loop completes reaching line 153
+        self::assertSame('', $result);
+    }
+
+    public function testApplyFixWithClassNameEnabled(): void
+    {
+        $code = '<?php class TestClass {}';
+        $tokens = Tokens::fromCode($code);
+        $file = new SplFileInfo(__FILE__);
+
+        $method = new ReflectionMethod($this->fixer, 'applyFix');
+        $method->setAccessible(true);
+
+        $this->fixer->configure([
+            'annotations' => ['author' => 'John Doe'],
+            'add_class_name' => true,
+            'separate' => 'none',
+        ]);
+        $method->invoke($this->fixer, $file, $tokens);
+
+        $expected = "<?php /**\n * TestClass.\n *\n * @author John Doe\n */class TestClass {}";
+        self::assertSame($expected, $tokens->generateCode());
+    }
+
+    public function testApplyFixWithMultipleClassesAndClassName(): void
+    {
+        $code = '<?php class FirstClass {} class SecondClass {}';
+        $tokens = Tokens::fromCode($code);
+        $file = new SplFileInfo(__FILE__);
+
+        $method = new ReflectionMethod($this->fixer, 'applyFix');
+        $method->setAccessible(true);
+
+        $this->fixer->configure([
+            'annotations' => ['author' => 'John Doe'],
+            'add_class_name' => true,
+            'separate' => 'none',
+        ]);
+        $method->invoke($this->fixer, $file, $tokens);
+
+        $result = $tokens->generateCode();
+        self::assertStringContainsString('FirstClass.', $result);
+        self::assertStringContainsString('SecondClass.', $result);
+        self::assertStringContainsString('@author John Doe', $result);
+    }
+
+    public function testMergeWithExistingDocBlockWithClassName(): void
+    {
+        $code = "<?php /**\n * @license MIT\n */ class TestClass {}";
+        $tokens = Tokens::fromCode($code);
+        $annotations = ['author' => 'John Doe'];
+
+        $method = new ReflectionMethod($this->fixer, 'mergeWithExistingDocBlock');
+        $method->setAccessible(true);
+
+        $this->fixer->configure(['add_class_name' => true]);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'TestClass');
+
+        $result = $tokens->generateCode();
+        self::assertStringContainsString('TestClass.', $result);
+        self::assertStringContainsString('@license MIT', $result);
+        self::assertStringContainsString('@author John Doe', $result);
+    }
+
+    public function testReplaceDocBlockWithClassName(): void
+    {
+        $code = "<?php /**\n * @license MIT\n */ class TestClass {}";
+        $tokens = Tokens::fromCode($code);
+        $annotations = ['author' => 'John Doe'];
+
+        $method = new ReflectionMethod($this->fixer, 'replaceDocBlock');
+        $method->setAccessible(true);
+
+        $this->fixer->configure(['add_class_name' => true]);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'TestClass');
+
+        $result = $tokens->generateCode();
+        self::assertStringContainsString('TestClass.', $result);
+        self::assertStringNotContainsString('@license MIT', $result);
+        self::assertStringContainsString('@author John Doe', $result);
+    }
+
+    public function testInsertNewDocBlockWithClassNameAndSeparateNone(): void
+    {
+        $code = '<?php class TestClass {}';
+        $tokens = Tokens::fromCode($code);
+        $annotations = ['author' => 'John Doe'];
+
+        $method = new ReflectionMethod($this->fixer, 'insertNewDocBlock');
+        $method->setAccessible(true);
+
+        $this->fixer->configure([
+            'add_class_name' => true,
+            'separate' => 'none',
+        ]);
+        $method->invoke($this->fixer, $tokens, 1, $annotations, 'TestClass');
+
+        $expected = "<?php /**\n * TestClass.\n *\n * @author John Doe\n */class TestClass {}";
+        self::assertSame($expected, $tokens->generateCode());
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to include the class name in generated PHP DocBlock headers when enabled in configuration.

* **Documentation**
  * Updated documentation to reflect the new configuration option for adding the class name to DocBlock headers.

* **Tests**
  * Extended and added tests to ensure correct handling and output of class names in DocBlock headers when the new option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->