### PR TITLE
refactor(!): remove 'package' annotation from DocBlock examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /.php-cs-fixer.cache
 /.phpunit.result.cache
 /.build
+/coverage-report
 /php-cs-fixer.xml
 /phpstan.xml
 /site

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ class MyClass
  * MyClass.
  *
  * @author Your Name <your@email.org>
- * @package MyPackage
  */
 class MyClass
 {
@@ -58,6 +57,9 @@ composer require --dev konradmichalik/php-doc-block-header-fixer
 
 Add the PHP-CS-Fixer rule in your `.php-cs-fixer.php` file:
 
+> [!NOTE]
+> This fixer is compatible with standard PHP-CS-Fixer rules. It avoids adding annotations that conflict with rules like `phpdoc_no_package` and follows spacing conventions compatible with `phpdoc_separation`.
+
 ```php
 <?php
 // ...
@@ -71,7 +73,6 @@ return (new PhpCsFixer\Config())
             'annotations' => [
                 'author' => 'Konrad Michalik <hej@konradmichalik.dev>',
                 'license' => 'GPL-3.0-or-later',
-                'package' => 'PhpDocBlockHeaderFixer',
             ],
             'preserve_existing' => true,
             'separate' => 'none',
@@ -96,7 +97,6 @@ return (new PhpCsFixer\Config())
             [
                 'author' => 'Konrad Michalik <hej@konradmichalik.dev>',
                 'license' => 'GPL-3.0-or-later',
-                'package' => 'PhpDocBlockHeaderFixer',
             ],
             preserveExisting: true,
             separate: \KonradMichalik\PhpDocBlockHeaderFixer\Enum\Separate::None,

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "konradmichalik/php-doc-block-header-fixer",
-	"description": "This packages contains a PHP-CS-Fixer rule to automatically fix the class header regarding PHP DocBlocks.",
+	"description": "This package contains a PHP-CS-Fixer rule to automatically fix the class header regarding PHP DocBlocks.",
 	"license": "GPL-3.0-or-later",
 	"type": "library",
 	"authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "konradmichalik/php-doc-block-header-fixer",
-	"description": "",
+	"description": "This packages contains a PHP-CS-Fixer rule to automatically fix the class header regarding PHP DocBlocks.",
 	"license": "GPL-3.0-or-later",
 	"type": "library",
 	"authors": [

--- a/tests/src/Generators/DocBlockHeaderTest.php
+++ b/tests/src/Generators/DocBlockHeaderTest.php
@@ -125,7 +125,6 @@ final class DocBlockHeaderTest extends TestCase
             'license' => 'MIT',
             'version' => '1.0.0',
             'since' => '1.0.0',
-            'package' => 'MyPackage',
             'subpackage' => 'SubPackage',
             'see' => 'https://example.com',
             'link' => 'https://example.com',

--- a/tests/src/Rules/DocBlockHeaderFixerTest.php
+++ b/tests/src/Rules/DocBlockHeaderFixerTest.php
@@ -97,10 +97,9 @@ final class DocBlockHeaderFixerTest extends TestCase
         $result = $method->invoke($this->fixer, [
             'author' => 'John Doe <john@example.com>',
             'license' => 'MIT',
-            'package' => 'MyPackage',
         ], '');
 
-        $expected = "/**\n * @author John Doe <john@example.com>\n * @license MIT\n * @package MyPackage\n */";
+        $expected = "/**\n * @author John Doe <john@example.com>\n * @license MIT\n */";
         self::assertSame($expected, $result);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified compatibility with standard PHP-CS-Fixer rules and phpdoc_separation; examples no longer show @package.

* **Tests**
  * Updated tests to reflect exclusion of @package from generated/validated docblocks.

* **Bug Fixes**
  * Adjusted docblock separation behavior to avoid extra blank lines and conflicts with related rules.

* **Chores**
  * Added /coverage-report to .gitignore and improved package description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->