### PR TITLE
feat: add support for skipping anonymous classes in DocBlock processing

### DIFF
--- a/src/Rules/DocBlockHeaderFixer.php
+++ b/src/Rules/DocBlockHeaderFixer.php
@@ -150,13 +150,18 @@ final class DocBlockHeaderFixer extends AbstractFixer implements ConfigurableFix
             }
 
             // T_ATTRIBUTE '#[' marks the start of an attribute (we exit it when going backwards)
-            if ($token->isGivenKind([T_ATTRIBUTE, T_FINAL, T_READONLY])) {
+            if ($token->isGivenKind(T_ATTRIBUTE)) {
                 $insideAttribute = false;
                 continue;
             }
 
             // Skip everything inside attributes
             if ($insideAttribute) {
+                continue;
+            }
+
+            // Skip modifiers that can appear between 'new' and 'class'
+            if ($token->isGivenKind([T_FINAL, T_READONLY])) {
                 continue;
             }
 

--- a/src/Rules/DocBlockHeaderFixer.php
+++ b/src/Rules/DocBlockHeaderFixer.php
@@ -121,9 +121,37 @@ final class DocBlockHeaderFixer extends AbstractFixer implements ConfigurableFix
                 continue;
             }
 
+            // Skip anonymous classes (preceded by 'new' keyword)
+            if ($token->isGivenKind(T_CLASS) && $this->isAnonymousClass($tokens, $index)) {
+                continue;
+            }
+
             $structureName = $this->getStructureName($tokens, $index);
             $this->processStructureDocBlock($tokens, $index, $annotations, $structureName);
         }
+    }
+
+    private function isAnonymousClass(Tokens $tokens, int $classIndex): bool
+    {
+        // Look backwards for 'new' keyword
+        for ($i = $classIndex - 1; $i >= 0; --$i) {
+            $token = $tokens[$i];
+
+            // Skip whitespace and attributes
+            if ($token->isWhitespace() || $token->isGivenKind(T_ATTRIBUTE)) {
+                continue;
+            }
+
+            // If we find 'new', it's an anonymous class
+            if ($token->isGivenKind(T_NEW)) {
+                return true;
+            }
+
+            // If we hit any other meaningful token, it's not anonymous
+            break;
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Skip adding DocBlock headers to anonymous classes to avoid incorrect docblocks and formatting issues, improving compatibility and stability.

- **Tests**
  - Adds tests validating anonymous vs. regular class handling, including attribute cases, to ensure correct detection and processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->