### PR TITLE
docs: remove early development warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,6 @@
 
 This packages contains a [PHP-CS-Fixer](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer) rule to automatically fix the header regarding PHP DocBlocks for classes, interfaces, traits and enums.
 
-> [!warning]
-> This package is in early development stage and may change significantly in the future. Use it at your own risk.
-
 **Before:**
 
 ```php
@@ -40,6 +37,7 @@ enum MyEnum {}
  * MyClass.
  *
  * @author Your Name <your@email.org>
+ * @license GPL-3.0-or-later
  */
 class MyClass
 {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined the README by removing an outdated warning block to reduce clutter and improve readability.
  * Enhanced the DocBlock “After” example by adding a license tag line, clarifying recommended licensing notation.
  * Improved consistency and clarity across documentation examples for smoother onboarding.
  * No functional or API changes; this update is purely editorial and informational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->