### PR TITLE
fix: enhance annotation parsing to support multiple values per tag

### DIFF
--- a/src/Rules/DocBlockHeaderFixer.php
+++ b/src/Rules/DocBlockHeaderFixer.php
@@ -327,7 +327,7 @@ final class DocBlockHeaderFixer extends AbstractFixer implements ConfigurableFix
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, string|array<string>>
      */
     private function parseExistingAnnotations(string $docBlockContent): array
     {
@@ -339,7 +339,19 @@ final class DocBlockHeaderFixer extends AbstractFixer implements ConfigurableFix
             if (preg_match('/^@(\w+)(?:\s+(.*))?$/', $line, $matches)) {
                 $tag = $matches[1];
                 $value = $matches[2] ?? '';
-                $annotations[$tag] = $value;
+
+                // If this tag already exists, convert to array or append to existing array
+                if (isset($annotations[$tag])) {
+                    // Convert existing single value to array
+                    if (!is_array($annotations[$tag])) {
+                        $annotations[$tag] = [$annotations[$tag]];
+                    }
+                    // Append new value to array
+                    $annotations[$tag][] = $value;
+                } else {
+                    // First occurrence, store as string
+                    $annotations[$tag] = $value;
+                }
             }
         }
 
@@ -347,7 +359,7 @@ final class DocBlockHeaderFixer extends AbstractFixer implements ConfigurableFix
     }
 
     /**
-     * @param array<string, string>               $existing
+     * @param array<string, string|array<string>> $existing
      * @param array<string, string|array<string>> $new
      *
      * @return array<string, string|array<string>>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation block parsing and merging now correctly preserves multiple occurrences of the same tag (duplicates are aggregated and retained instead of overwritten).

* **Tests**
  * Added tests ensuring parsing, merging, and fixes preserve duplicate documentation tags and maintain correct order and values across round-trips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->