### PR TITLE
fix: support readonly modifier in DocBlockHeaderFixer

### DIFF
--- a/src/Rules/DocBlockHeaderFixer.php
+++ b/src/Rules/DocBlockHeaderFixer.php
@@ -223,7 +223,7 @@ final class DocBlockHeaderFixer extends AbstractFixer implements ConfigurableFix
             }
 
             // If we hit any other meaningful token (except modifiers), stop looking
-            if (!$token->isGivenKind([\T_FINAL, \T_ABSTRACT, \T_ATTRIBUTE])) {
+            if (!$token->isGivenKind([\T_FINAL, \T_ABSTRACT, \T_READONLY, \T_ATTRIBUTE])) {
                 break;
             }
         }
@@ -315,7 +315,7 @@ final class DocBlockHeaderFixer extends AbstractFixer implements ConfigurableFix
                 continue;
             }
 
-            if ($token->isGivenKind([\T_FINAL, \T_ABSTRACT, \T_ATTRIBUTE])) {
+            if ($token->isGivenKind([\T_FINAL, \T_ABSTRACT, \T_READONLY, \T_ATTRIBUTE])) {
                 $insertIndex = $i;
                 continue;
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended DocBlock insertion to properly recognize and handle PHP 8.2 readonly modifiers, ensuring consistent behavior with other class modifiers.

* **Tests**
  * Added comprehensive test coverage for readonly modifier scenarios in class declarations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->