### PR TITLE
refactor: migrate code to php 8.2

### DIFF
--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -7,3 +7,5 @@ on:
 jobs:
   cgl:
     uses: jackd248/reusable-github-actions/.github/workflows/cgl.yml@main
+    with:
+      php-version: '8.2'

--- a/.github/workflows/cgl.yml
+++ b/.github/workflows/cgl.yml
@@ -7,5 +7,3 @@ on:
 jobs:
   cgl:
     uses: jackd248/reusable-github-actions/.github/workflows/cgl.yml@main
-    with:
-      php-version: '8.2'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,5 +8,5 @@ jobs:
   tests:
     uses: jackd248/reusable-github-actions/.github/workflows/tests-php.yml@main
     with:
-      php-versions: '["8.1", "8.2", "8.3", "8.4", "8.5"]'
+      php-versions: '["8.2", "8.3", "8.4", "8.5"]'
       dependencies: '["highest", "lowest"]'

--- a/composer.json
+++ b/composer.json
@@ -21,18 +21,18 @@
 		}
 	],
 	"require": {
-		"php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+		"php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
 		"ext-tokenizer": "*",
 		"friendsofphp/php-cs-fixer": "^3.14"
 	},
 	"require-dev": {
-		"armin/editorconfig-cli": "^1.0 || ^2.0",
+		"armin/editorconfig-cli": "^2.0",
 		"ergebnis/composer-normalize": "^2.44",
 		"konradmichalik/php-cs-fixer-preset": "^0.1.0",
 		"phpstan/phpstan": "^2.0",
 		"phpstan/phpstan-phpunit": "^2.0",
 		"phpstan/phpstan-symfony": "^2.0",
-		"phpunit/phpunit": "^10.2 || ^11.0 || ^12.0",
+		"phpunit/phpunit": "^11.0 || ^12.0",
 		"rector/rector": "^2.2"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4fda84f7cc19f52985bd16834bfdaaa",
+    "content-hash": "d8443981b921cc6ec417859d1940f5d6",
     "packages": [
         {
             "name": "clue/ndjson-react",
@@ -5526,7 +5526,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
         "ext-tokenizer": "*"
     },
     "platform-dev": {},

--- a/rector.php
+++ b/rector.php
@@ -21,9 +21,9 @@ return RectorConfig::configure()
         __DIR__.'/src',
         __DIR__.'/tests',
     ])
-    ->withPhpVersion(PhpVersion::PHP_81)
+    ->withPhpVersion(PhpVersion::PHP_82)
     ->withSets([
-        LevelSetList::UP_TO_PHP_81,
+        LevelSetList::UP_TO_PHP_82,
     ])
     ->withComposerBased(symfony: true)
     ->withRules([

--- a/src/Generators/DocBlockHeader.php
+++ b/src/Generators/DocBlockHeader.php
@@ -29,14 +29,14 @@ use function sprintf;
  * @author Konrad Michalik <hej@konradmichalik.dev>
  * @license GPL-3.0-or-later
  */
-final class DocBlockHeader implements Generator
+final readonly class DocBlockHeader implements Generator
 {
     private function __construct(
         /** @var array<string, string|array<string>> */
-        public readonly array $annotations,
-        public readonly bool $preserveExisting,
-        public readonly Separate $separate,
-        public readonly bool $addStructureName,
+        public array $annotations,
+        public bool $preserveExisting,
+        public Separate $separate,
+        public bool $addStructureName,
     ) {}
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum PHP version requirement to 8.2; PHP 8.1 is no longer supported.
  * Updated CI/CD workflows and development dependencies to align with new PHP version support.

* **Refactor**
  * Adjusted internal class structure for improved flexibility and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->